### PR TITLE
use sdk client instead of gRPC client

### DIFF
--- a/internal/controller/clientpool/clientpool.go
+++ b/internal/controller/clientpool/clientpool.go
@@ -11,8 +11,7 @@ import (
 	"os"
 	"sync"
 
-	"go.temporal.io/api/workflowservice/v1"
-	"go.temporal.io/sdk/client"
+	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/log"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -21,29 +20,33 @@ import (
 	"github.com/DataDog/temporal-worker-controller/api/v1alpha1"
 )
 
+type ClientPoolKey struct {
+	HostPort  string
+	Namespace string
+}
+
 type ClientPool struct {
 	mux       sync.RWMutex
 	logger    log.Logger
-	clients   map[string]client.Client
+	clients   map[ClientPoolKey]sdkclient.Client
 	k8sClient runtimeclient.Client
 }
 
 func New(l log.Logger, c runtimeclient.Client) *ClientPool {
 	return &ClientPool{
 		logger:    l,
-		clients:   make(map[string]client.Client),
+		clients:   make(map[ClientPoolKey]sdkclient.Client),
 		k8sClient: c,
 	}
 }
 
-// TODO(carlydf): Replace with sdk client (scoped by ns). One controller could need to manage workers for multiple temporal namespaces and/or clusters (self-hosted)
-func (cp *ClientPool) GetWorkflowServiceClient(hostPort string) (workflowservice.WorkflowServiceClient, bool) {
+func (cp *ClientPool) GetSDKClient(key ClientPoolKey) (sdkclient.Client, bool) {
 	cp.mux.RLock()
 	defer cp.mux.RUnlock()
 
-	c, ok := cp.clients[hostPort]
+	c, ok := cp.clients[key]
 	if ok {
-		return c.WorkflowService(), true
+		return c, true
 	}
 	return nil, false
 }
@@ -54,13 +57,13 @@ type NewClientOptions struct {
 	Spec              v1alpha1.TemporalConnectionSpec
 }
 
-func (cp *ClientPool) UpsertClient(ctx context.Context, opts NewClientOptions) (workflowservice.WorkflowServiceClient, error) {
-	clientOpts := client.Options{
+func (cp *ClientPool) UpsertClient(ctx context.Context, opts NewClientOptions) (sdkclient.Client, error) {
+	clientOpts := sdkclient.Options{
 		Logger:    cp.logger,
 		HostPort:  opts.Spec.HostPort,
 		Namespace: opts.TemporalNamespace,
 		// TODO(jlegrone): fix this
-		Credentials: client.NewAPIKeyStaticCredentials(os.Getenv("TEMPORAL_CLOUD_API_KEY")),
+		Credentials: sdkclient.NewAPIKeyStaticCredentials(os.Getenv("TEMPORAL_CLOUD_API_KEY")),
 		//Credentials: client.NewAPIKeyDynamicCredentials(func(ctx context.Context) (string, error) {
 		//	token, ok := os.LookupEnv("TEMPORAL_CLOUD_API_KEY")
 		//	if ok {
@@ -102,21 +105,25 @@ func (cp *ClientPool) UpsertClient(ctx context.Context, opts NewClientOptions) (
 		}
 	}
 
-	c, err := client.Dial(clientOpts)
+	c, err := sdkclient.Dial(clientOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := c.CheckHealth(context.Background(), &client.CheckHealthRequest{}); err != nil {
+	if _, err := c.CheckHealth(context.Background(), &sdkclient.CheckHealthRequest{}); err != nil {
 		panic(err)
 	}
 
 	cp.mux.Lock()
 	defer cp.mux.Unlock()
 
-	cp.clients[opts.Spec.HostPort] = c
+	key := ClientPoolKey{
+		HostPort:  opts.Spec.HostPort,
+		Namespace: opts.TemporalNamespace,
+	}
+	cp.clients[key] = c
 
-	return c.WorkflowService(), nil
+	return c, nil
 }
 
 func (cp *ClientPool) Close() {
@@ -127,5 +134,5 @@ func (cp *ClientPool) Close() {
 		c.Close()
 	}
 
-	cp.clients = make(map[string]client.Client)
+	cp.clients = make(map[ClientPoolKey]sdkclient.Client)
 }

--- a/internal/controller/genplan.go
+++ b/internal/controller/genplan.go
@@ -22,8 +22,8 @@ import (
 type plan struct {
 	// Where to take actions
 
-	TemporalNamespace string
-	DeploymentName    string
+	TemporalNamespace    string
+	WorkerDeploymentName string
 
 	// Which actions to take
 
@@ -65,9 +65,9 @@ func (r *TemporalWorkerDeploymentReconciler) generatePlan(
 	connection temporaliov1alpha1.TemporalConnectionSpec,
 ) (*plan, error) {
 	plan := plan{
-		TemporalNamespace: w.Spec.WorkerOptions.TemporalNamespace,
-		DeploymentName:    computeWorkerDeploymentName(w),
-		ScaleDeployments:  make(map[*v1.ObjectReference]uint32),
+		TemporalNamespace:    w.Spec.WorkerOptions.TemporalNamespace,
+		WorkerDeploymentName: computeWorkerDeploymentName(w),
+		ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
 	}
 
 	// Scale the active deployment if it doesn't match desired replicas
@@ -182,7 +182,7 @@ func (r *TemporalWorkerDeploymentReconciler) generatePlan(
 						if _, ok := taskQueuesWithWorkflows[tq.Name]; !ok {
 							plan.startTestWorkflows = append(plan.startTestWorkflows, startWorkflowConfig{
 								workflowType: w.Spec.RolloutStrategy.Gate.WorkflowType,
-								workflowID:   getTestWorkflowID(plan.DeploymentName, tq.Name, targetVersion.VersionID),
+								workflowID:   getTestWorkflowID(plan.WorkerDeploymentName, tq.Name, targetVersion.VersionID),
 								versionID:    targetVersion.VersionID,
 								taskQueue:    tq.Name,
 							})

--- a/internal/controller/genstatus.go
+++ b/internal/controller/genstatus.go
@@ -15,11 +15,11 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflow/v1"
-	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	temporalClient "go.temporal.io/sdk/client"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -228,7 +228,7 @@ func newDeploymentVersionCollection() deploymentVersionCollection {
 	}
 }
 
-func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context, l logr.Logger, temporalClient workflowservice.WorkflowServiceClient, req ctrl.Request, workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment) (*temporaliov1alpha1.TemporalWorkerDeploymentStatus, error) {
+func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context, l logr.Logger, temporalClient temporalClient.Client, req ctrl.Request, workerDeploy *temporaliov1alpha1.TemporalWorkerDeployment) (*temporaliov1alpha1.TemporalWorkerDeploymentStatus, error) {
 	var (
 		desiredVersionID, defaultVersionID string
 		deployedVersions                   []string
@@ -258,87 +258,84 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context,
 		// TODO(jlegrone): implement some error handling (maybe a human deleted the label?)
 	}
 
+	// Get deployment handler
+	deploymentHandler := temporalClient.WorkerDeploymentClient().GetHandle(workerDeploymentName)
+
 	// List deployment versions in Temporal
-	describeResp, err := describeWorkerDeploymentHandleNotFound(ctx, temporalClient, &workflowservice.DescribeWorkerDeploymentRequest{
-		Namespace:      workerDeploy.Spec.WorkerOptions.TemporalNamespace,
-		DeploymentName: workerDeploymentName,
-	})
+	describeResp, err := describeWorkerDeploymentHandleNotFound(ctx, deploymentHandler, workerDeploymentName)
 	if err != nil {
 		return nil, fmt.Errorf("unable to describe worker deployment %s: %w", workerDeploymentName, err)
 	}
-	workerDeploymentInfo := describeResp.GetWorkerDeploymentInfo()
-	routingConfig := workerDeploymentInfo.GetRoutingConfig()
-	defaultVersionID = routingConfig.GetCurrentVersion()
+	workerDeploymentInfo := describeResp.Info
+	routingConfig := workerDeploymentInfo.RoutingConfig
+	defaultVersionID = routingConfig.CurrentVersion
 
 	// Check if the worker deployment was modified out of band of the controller (eg. via the Temporal CLI)
-	if workerDeploymentInfo.GetLastModifierIdentity() != "temporal-worker-controller" &&
-		workerDeploymentInfo.GetLastModifierIdentity() != "" {
+	if workerDeploymentInfo.LastModifierIdentity != "temporal-worker-controller" &&
+		workerDeploymentInfo.LastModifierIdentity != "" {
 		// TODO(jlegrone): if it was set by another client, switch to manual mode
 	}
 
 	var rampingSinceTime *metav1.Time
 	var rampPercentage float32
 	// For each version the server has registered in the worker deployment, compute the status.
-	for _, version := range workerDeploymentInfo.GetVersionSummaries() {
-		drainageStatus := version.GetDrainageStatus()
+	for _, version := range workerDeploymentInfo.VersionSummaries {
+		drainageStatus := version.DrainageStatus
 		var versionStatus temporaliov1alpha1.VersionStatus
-		if version.GetVersion() == routingConfig.GetCurrentVersion() {
+		if version.Version == routingConfig.CurrentVersion {
 			versionStatus = temporaliov1alpha1.VersionStatusCurrent
-		} else if version.GetVersion() == routingConfig.GetRampingVersion() {
+		} else if version.Version == routingConfig.RampingVersion {
 			versionStatus = temporaliov1alpha1.VersionStatusRamping
-			rt := metav1.NewTime(routingConfig.GetRampingVersionChangedTime().AsTime())
+			rt := metav1.NewTime(routingConfig.RampingVersionChangedTime)
 			rampingSinceTime = &rt
-			rampPercentage = routingConfig.GetRampingVersionPercentage()
-			l.Info(fmt.Sprintf("version %s has been ramping since %s, current ramp percentage %v", version.GetVersion(), rt.String(), rampPercentage))
-		} else if drainageStatus == enums.VERSION_DRAINAGE_STATUS_DRAINING {
+			rampPercentage = routingConfig.RampingVersionPercentage
+			l.Info(fmt.Sprintf("version %s has been ramping since %s, current ramp percentage %v", version.Version, rt.String(), rampPercentage))
+		} else if drainageStatus == sdkclient.WorkerDeploymentVersionDrainageStatusDraining {
 			versionStatus = temporaliov1alpha1.VersionStatusDraining
-		} else if drainageStatus == enums.VERSION_DRAINAGE_STATUS_DRAINED {
+		} else if drainageStatus == sdkclient.WorkerDeploymentVersionDrainageStatusDrained {
 			versionStatus = temporaliov1alpha1.VersionStatusDrained
 			// see when it was drained
-			versionResp, err := temporalClient.DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
-				Namespace: workerDeploy.Spec.WorkerOptions.TemporalNamespace,
-				Version:   version.GetVersion(),
+			versionResp, err := deploymentHandler.DescribeVersion(ctx, sdkclient.WorkerDeploymentDescribeVersionOptions{
+				Version: version.Version,
 			})
 			if err != nil {
 				l.Error(err, "unable to describe version to see when it drained")
 				return nil, fmt.Errorf("unable to describe version for version %q: %w", version, err)
 			}
-			drainedSinceTime := versionResp.GetWorkerDeploymentVersionInfo().GetDrainageInfo().GetLastChangedTime()
-			versions.addDrainedSince(version.GetVersion(), drainedSinceTime.AsTime())
+			drainedSinceTime := versionResp.Info.DrainageInfo.LastChangedTime
+			versions.addDrainedSince(version.Version, drainedSinceTime)
 		} else {
 			versionStatus = temporaliov1alpha1.VersionStatusInactive
 		}
-		versions.addVersionStatus(version.GetVersion(), versionStatus)
+		versions.addVersionStatus(version.Version, versionStatus)
 	}
 
 	// Check the status of the test workflow for the next version, if rollout is still happening.
-	if desiredVersionID != routingConfig.GetCurrentVersion() {
+	if desiredVersionID != routingConfig.CurrentVersion {
 		// Describe the desired version to get task queue information
 		// Temporal will error if any task queue in the existing current version is not present in the new current version.
 		// Temporal will also error if any task queue in the existing current version is not present in the new ramping version.
-		versionResp, err := temporalClient.DescribeWorkerDeploymentVersion(ctx, &workflowservice.DescribeWorkerDeploymentVersionRequest{
-			Namespace: workerDeploy.Spec.WorkerOptions.TemporalNamespace,
-			Version:   desiredVersionID,
+		versionResp, err := deploymentHandler.DescribeVersion(ctx, sdkclient.WorkerDeploymentDescribeVersionOptions{
+			Version: desiredVersionID,
 		})
 		var notFound *serviceerror.NotFound
 		if err != nil && !errors.As(err, &notFound) {
 			// Ignore NotFound error, because if the version is not found, we know there are no test workflows running on it.
 			return nil, fmt.Errorf("unable to describe worker deployment version for version %q: %w", desiredVersionID, err)
 		}
-		for _, tq := range versionResp.GetWorkerDeploymentVersionInfo().GetTaskQueueInfos() {
+		for _, tq := range versionResp.Info.TaskQueuesInfos {
 			// Keep track of which task queues this version of the worker is polling on
-			if tq.GetType() != enums.TASK_QUEUE_TYPE_WORKFLOW {
+			if tq.Type != sdkclient.TaskQueueTypeWorkflow {
 				continue
 			}
-			versions.addTaskQueue(desiredVersionID, tq.GetName())
+			versions.addTaskQueue(desiredVersionID, tq.Name)
 
 			// If there is a test workflow associated with this task queue and build id, check its status.
-			wf, err := temporalClient.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
-				Namespace: workerDeploy.Spec.WorkerOptions.TemporalNamespace,
-				Execution: &common.WorkflowExecution{
-					WorkflowId: getTestWorkflowID(computeWorkerDeploymentName(workerDeploy), tq.GetName(), desiredVersionID),
-				},
-			})
+			wf, err := temporalClient.DescribeWorkflowExecution(
+				ctx,
+				getTestWorkflowID(computeWorkerDeploymentName(workerDeploy), tq.Name, desiredVersionID),
+				"",
+			)
 			// TODO(jlegrone): Detect "not found" errors properly
 			if err != nil && !strings.Contains(err.Error(), "workflow not found") {
 				return nil, fmt.Errorf("unable to describe test workflow: %w", err)

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -89,7 +89,10 @@ func (r *TemporalWorkerDeploymentReconciler) Reconcile(ctx context.Context, req 
 	}
 
 	// Get or update temporal client for connection
-	temporalClient, ok := r.TemporalClientPool.GetWorkflowServiceClient(temporalConnection.Spec.HostPort)
+	temporalClient, ok := r.TemporalClientPool.GetSDKClient(clientpool.ClientPoolKey{
+		HostPort:  temporalConnection.Spec.HostPort,
+		Namespace: workerDeploy.Spec.WorkerOptions.TemporalNamespace,
+	})
 	if !ok {
 		c, err := r.TemporalClientPool.UpsertClient(ctx, clientpool.NewClientOptions{
 			K8sNamespace:      workerDeploy.Namespace,

--- a/internal/demo/helloworld/worker.go
+++ b/internal/demo/helloworld/worker.go
@@ -34,7 +34,7 @@ func HelloWorld(ctx workflow.Context) (string, error) {
 }
 
 func GetSubject(ctx context.Context) (string, error) {
-	return "World2", nil
+	return "World10", nil
 }
 
 func Sleep(ctx context.Context, seconds uint) error {


### PR DESCRIPTION
- Use (namespace, cluster address) tuple as the key for the client cache
- Replace gRPC client with SDK client