### PR TITLE
add scaledown delay before deleting deployments 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flowchart TD
       twd[TemporalWorkerDeployment 'foo']
       
       subgraph "Current/default version"
-        d5["Deployment foo-v5 (Version ns/foo.v5)"]
+        d5["Deployment foo-v5 (Version foo/ns.v5)"]
         rs5["ReplicaSet foo-v5"]
         p5a["Pod foo-v5-a"]
         p5b["Pod foo-v5-b"]
@@ -88,7 +88,7 @@ flowchart TD
       end
 
       subgraph "Deprecated versions"
-        d1["Deployment foo-v1 (Version ns/foo.v1)"]
+        d1["Deployment foo-v1 (Version foo/ns.v1)"]
         rs1["ReplicaSet foo-v1"]
         p1a["Pod foo-v1-a"]
         p1b["Pod foo-v1-b"]
@@ -104,12 +104,12 @@ flowchart TD
     twd --> dN
     twd --> d5
 
-    p1a -. "poll version ns/foo.v1" .-> server
-    p1b -. "poll version ns/foo.v1" .-> server
+    p1a -. "poll version foo/ns.v1" .-> server
+    p1b -. "poll version foo/ns.v1" .-> server
 
-    p5a -. "poll version ns/foo.v5" .-> server
-    p5b -. "poll version ns/foo.v5" .-> server
-    p5c -. "poll version ns/foo.v5" .-> server
+    p5a -. "poll version foo/ns.v5" .-> server
+    p5b -. "poll version foo/ns.v5" .-> server
+    p5c -. "poll version foo/ns.v5" .-> server
 
     server["Temporal Server"]
 ```
@@ -147,14 +147,14 @@ sequenceDiagram
     Dev->>K8s: Create TemporalWorkerDeployment "foo" (v1)
     K8s-->>Ctl: Notify TemporalWorkerDeployment "foo" created
     Ctl->>K8s: Create Deployment "foo-v1"
-    Ctl->>T: Register "ns/foo.v1" as new current version of "ns/foo"
+    Ctl->>T: Register "foo/ns.v1" as new current version of "foo/ns"
     Dev->>K8s: Update TemporalWorker "foo" (v2)
     K8s-->>Ctl: Notify TemporalWorker "foo" updated
     Ctl->>K8s: Create Deployment "foo-v2"
-    Ctl->>T: Register "ns/foo.v2" as new current version of "ns/foo"
+    Ctl->>T: Register "foo/ns.v2" as new current version of "foo/ns"
     
     loop Poll Temporal API
-        Ctl-->>T: Wait for "ns/foo.v1" to be drained (no open pinned wfs)
+        Ctl-->>T: Wait for "foo/ns.v1" to be drained (no open pinned wfs)
     end
     
     Ctl->>K8s: Delete Deployment "foo-v1"

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ flowchart TD
       twd[TemporalWorkerDeployment 'foo']
       
       subgraph "Current/default version"
-        d5["Deployment foo-v5 (Version foo/ns.v5)"]
+        d5["Deployment foo-v5 (Version ns/foo.v5)"]
         rs5["ReplicaSet foo-v5"]
         p5a["Pod foo-v5-a"]
         p5b["Pod foo-v5-b"]
@@ -88,7 +88,7 @@ flowchart TD
       end
 
       subgraph "Deprecated versions"
-        d1["Deployment foo-v1 (Version foo/ns.v1)"]
+        d1["Deployment foo-v1 (Version ns/foo.v1)"]
         rs1["ReplicaSet foo-v1"]
         p1a["Pod foo-v1-a"]
         p1b["Pod foo-v1-b"]
@@ -104,12 +104,12 @@ flowchart TD
     twd --> dN
     twd --> d5
 
-    p1a -. "poll version foo/ns.v1" .-> server
-    p1b -. "poll version foo/ns.v1" .-> server
+    p1a -. "poll version ns/foo.v1" .-> server
+    p1b -. "poll version ns/foo.v1" .-> server
 
-    p5a -. "poll version foo/ns.v5" .-> server
-    p5b -. "poll version foo/ns.v5" .-> server
-    p5c -. "poll version foo/ns.v5" .-> server
+    p5a -. "poll version ns/foo.v5" .-> server
+    p5b -. "poll version ns/foo.v5" .-> server
+    p5c -. "poll version ns/foo.v5" .-> server
 
     server["Temporal Server"]
 ```
@@ -147,14 +147,14 @@ sequenceDiagram
     Dev->>K8s: Create TemporalWorkerDeployment "foo" (v1)
     K8s-->>Ctl: Notify TemporalWorkerDeployment "foo" created
     Ctl->>K8s: Create Deployment "foo-v1"
-    Ctl->>T: Register "foo/ns.v1" as new current version of "foo/ns"
+    Ctl->>T: Register "ns/foo.v1" as new current version of "ns/foo"
     Dev->>K8s: Update TemporalWorker "foo" (v2)
     K8s-->>Ctl: Notify TemporalWorker "foo" updated
     Ctl->>K8s: Create Deployment "foo-v2"
-    Ctl->>T: Register "foo/ns.v2" as new current version of "foo/ns"
+    Ctl->>T: Register "ns/foo.v2" as new current version of "ns/foo"
     
     loop Poll Temporal API
-        Ctl-->>T: Wait for "foo/ns.v1" to be drained (no open pinned wfs)
+        Ctl-->>T: Wait for "ns/foo.v1" to be drained (no open pinned wfs)
     end
     
     Ctl->>K8s: Delete Deployment "foo-v1"

--- a/internal/controller/genstatus.go
+++ b/internal/controller/genstatus.go
@@ -29,6 +29,7 @@ import (
 	temporaliov1alpha1 "github.com/DataDog/temporal-worker-controller/api/v1alpha1"
 )
 
+// TODO (Shivam): Should we be having a map of [versionID] -> Structure?
 type deploymentVersionCollection struct {
 	versionIDsToDeployments map[string]*appsv1.Deployment
 	// map of version IDs to ramp percentages [0,100]
@@ -388,7 +389,7 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context,
 		case desiredVersionID, defaultVersionID:
 			continue
 		}
-		d, _ := versions.getWorkerDeploymentVersion(version)
+		d, _ := versions.getWorkerDeploymentVersion(version) // TODO (Shivam): How do we know these versions have been deleted by Temporal? They could just be draining...
 		deprecatedVersions = append(deprecatedVersions, d)
 	}
 
@@ -399,7 +400,7 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context,
 
 	// Ugly hack to clear ramp percentages (not quite correctly) for now
 	for _, d := range deprecatedVersions {
-		d.RampPercentage = nil
+		d.RampPercentage = nil // TODO (Shivam): All deprecatedVersions will have rampPercentage set to nil already
 	}
 	if defaultVersion != nil {
 		defaultVersion.RampPercentage = nil

--- a/internal/controller/genstatus.go
+++ b/internal/controller/genstatus.go
@@ -8,11 +8,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"go.temporal.io/api/serviceerror"
-	"math"
 	"sort"
 	"strings"
 	"time"
+
+	"go.temporal.io/api/serviceerror"
 
 	"github.com/go-logr/logr"
 	"go.temporal.io/api/enums/v1"
@@ -139,13 +139,11 @@ func (c *deploymentVersionCollection) addAssignmentRule(rule *taskqueue.BuildIdA
 
 func (c *deploymentVersionCollection) addVersionStatus(version string, status temporaliov1alpha1.VersionStatus) {
 	c.versionStatus[version] = status
-	return
 }
 
 func (c *deploymentVersionCollection) addDrainedSince(version string, drainedSince time.Time) {
 	t := metav1.NewTime(drainedSince)
 	c.drainedSince[version] = &t
-	return
 }
 
 func (c *deploymentVersionCollection) addTaskQueue(versionID, name string) {
@@ -400,7 +398,7 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context,
 
 	// Ugly hack to clear ramp percentages (not quite correctly) for now
 	for _, d := range deprecatedVersions {
-		d.RampPercentage = nil // TODO (Shivam): All deprecatedVersions will have rampPercentage set to nil already
+		d.RampPercentage = nil
 	}
 	if defaultVersion != nil {
 		defaultVersion.RampPercentage = nil
@@ -419,8 +417,4 @@ func (r *TemporalWorkerDeploymentReconciler) generateStatus(ctx context.Context,
 		DeprecatedVersions:   deprecatedVersions,
 		VersionConflictToken: []byte("todo"),
 	}, nil
-}
-
-func convertFloatToUint(val float32) uint8 {
-	return uint8(math.Round(float64(val)))
 }

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -8,13 +8,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/go-logr/logr"
 	"go.temporal.io/api/serviceerror"
 	sdkclient "go.temporal.io/sdk/client"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"strings"
-	"time"
 
 	temporaliov1alpha1 "github.com/DataDog/temporal-worker-controller/api/v1alpha1"
 	"github.com/DataDog/temporal-worker-controller/internal/controller/k8s.io/utils"
@@ -29,7 +30,7 @@ const (
 )
 
 func computeWorkerDeploymentName(w *temporaliov1alpha1.TemporalWorkerDeployment) string {
-	return w.GetName() + deploymentNameSeparator + w.GetNamespace()
+	return w.GetNamespace() + deploymentNameSeparator + w.GetName()
 }
 
 func computeVersionID(r *temporaliov1alpha1.TemporalWorkerDeployment) string {

--- a/internal/controller/util.go
+++ b/internal/controller/util.go
@@ -30,7 +30,7 @@ const (
 )
 
 func computeWorkerDeploymentName(w *temporaliov1alpha1.TemporalWorkerDeployment) string {
-	return w.GetNamespace() + deploymentNameSeparator + w.GetName()
+	return w.GetName() + deploymentNameSeparator + w.GetNamespace()
 }
 
 func computeVersionID(r *temporaliov1alpha1.TemporalWorkerDeployment) string {

--- a/internal/controller/worker_controller.go
+++ b/internal/controller/worker_controller.go
@@ -32,7 +32,7 @@ const (
 	buildIDLabel   = "temporal.io/build-id"
 )
 
-// TemporalWorkerDeploymentReconciler reconciles a TemporalWorker object
+// TemporalWorkerDeploymentReconciler reconciles a TemporalWorkerDeployment object
 type TemporalWorkerDeploymentReconciler struct {
 	client.Client
 	Scheme             *runtime.Scheme

--- a/internal/controller/worker_controller_test.go
+++ b/internal/controller/worker_controller_test.go
@@ -43,7 +43,7 @@ var (
 	testNamespace = "ns"
 )
 
-// Hash is always taken of this for generating the buildID.
+// Hash is always taken of Spec.Template for generating the buildID.
 func newTestWorkerSpec(replicas int32) *temporaliov1alpha1.TemporalWorkerDeploymentSpec {
 	return &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
 		Replicas: &replicas,
@@ -248,7 +248,7 @@ func TestGeneratePlan(t *testing.T) {
 				UpdateVersionConfig: nil,
 			},
 		},
-		"create new k8s deployment from the pod template ": {
+		"create new k8s deployment from the pod template": {
 			workerDeploymentName: "baz",
 			observedReplicas:     3,
 			desiredReplicas:      3,
@@ -268,7 +268,7 @@ func TestGeneratePlan(t *testing.T) {
 				UpdateVersionConfig:  nil,
 			},
 		},
-		"delete unreachable deployment versions": {
+		"delete unregistered deployment version": {
 			workerDeploymentName: "bar",
 			observedReplicas:     3,
 			desiredReplicas:      3,

--- a/internal/controller/worker_controller_test.go
+++ b/internal/controller/worker_controller_test.go
@@ -127,7 +127,7 @@ func newTestDeploymentWithBuildID(podSpec v1.PodTemplateSpec, desiredState *temp
 func newTestWorkerDeploymentVersion(status temporaliov1alpha1.VersionStatus, deploymentName string, buildID string, managedK8Deployment bool) *temporaliov1alpha1.WorkerDeploymentVersion {
 	result := temporaliov1alpha1.WorkerDeploymentVersion{
 		HealthySince:   nil,
-		VersionID:      deploymentName + versionIDSeparator + buildID,
+		VersionID:      deploymentName + deploymentNameSeparator + testNamespace + versionIDSeparator + buildID,
 		Status:         status,
 		RampPercentage: nil,
 		Deployment:     nil,

--- a/internal/controller/worker_controller_test.go
+++ b/internal/controller/worker_controller_test.go
@@ -6,20 +6,30 @@ package controller
 
 import (
 	"context"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
 	"testing"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	temporaliov1alpha1 "github.com/DataDog/temporal-worker-controller/api/v1alpha1"
+	"github.com/DataDog/temporal-worker-controller/internal/controller/k8s.io/utils"
 )
 
 var (
 	testPodTemplate = v1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"temporal.io/build-id": "123456789",
+			},
+		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
@@ -29,152 +39,413 @@ var (
 			},
 		},
 	}
+
+	testNamespace = "ns"
 )
 
+// Hash is always taken of this for generating the buildID.
 func newTestWorkerSpec(replicas int32) *temporaliov1alpha1.TemporalWorkerDeploymentSpec {
 	return &temporaliov1alpha1.TemporalWorkerDeploymentSpec{
 		Replicas: &replicas,
 		Template: testPodTemplate,
 		WorkerOptions: temporaliov1alpha1.WorkerOptions{
-			TemporalNamespace: "baz",
+			TemporalNamespace: testNamespace,
 		},
 	}
 }
 
-func newTestDeployment(podSpec v1.PodTemplateSpec, desiredReplicas int32) *appsv1.Deployment {
+// This is the new Deployment object that will be created by the controller based on the hash of the TemporalWorkerDeploymentSpec
+func newTestDeploymentWithHashedBuildID(podSpec v1.PodTemplateSpec, desiredState *temporaliov1alpha1.TemporalWorkerDeploymentSpec, deploymentName string) *appsv1.Deployment {
+	buildID := utils.ComputeHash(&desiredState.Template, nil)
+
+	labels := map[string]string{
+		"temporal.io/build-id": buildID,
+	}
+
+	blockOwnerDeletion := true
+	isController := true
+
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "foo",
-			Name:      "bar-7476c6b88c",
-			Annotations: map[string]string{
-				"temporal.io/build-id": "7476c6b88c",
-			},
+			Namespace: testNamespace,
+			Name:      deploymentName + k8sResourceNameSeparator + buildID,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "temporal.io/v1alpha1",
+				Kind:               "TemporalWorkerDeployment",
+				Name:               deploymentName,
+				UID:                "",
+				Controller:         &isController,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			}},
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: &desiredReplicas,
+			Replicas: desiredState.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
 			Template: podSpec,
 		},
 	}
 }
 
-func newTestWorkerDeploymentVersion(status temporaliov1alpha1.VersionStatus, deploymentName string) *temporaliov1alpha1.WorkerDeploymentVersion {
+func newTestDeploymentWithBuildID(podSpec v1.PodTemplateSpec, desiredState *temporaliov1alpha1.TemporalWorkerDeploymentSpec, deploymentName string, buildID string) *appsv1.Deployment {
+
+	labels := map[string]string{
+		"temporal.io/build-id": buildID,
+	}
+
+	blockOwnerDeletion := true
+	isController := true
+
+	return &appsv1.Deployment{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      deploymentName + k8sResourceNameSeparator + buildID,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion:         "temporal.io/v1alpha1",
+				Kind:               "TemporalWorkerDeployment",
+				Name:               deploymentName,
+				UID:                "",
+				Controller:         &isController,
+				BlockOwnerDeletion: &blockOwnerDeletion,
+			}},
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: desiredState.Replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: labels,
+			},
+			Template: podSpec,
+		},
+	}
+}
+
+func newTestWorkerDeploymentVersion(status temporaliov1alpha1.VersionStatus, deploymentName string, buildID string, managedK8Deployment bool) *temporaliov1alpha1.WorkerDeploymentVersion {
 	result := temporaliov1alpha1.WorkerDeploymentVersion{
 		HealthySince:   nil,
-		VersionID:      deploymentName + "." + "test-id",
+		VersionID:      deploymentName + versionIDSeparator + buildID,
 		Status:         status,
 		RampPercentage: nil,
 		Deployment:     nil,
+		DrainedSince:   &metav1.Time{Time: time.Now().Add(-30 * time.Hour)}, // useful when testing versions that have been drained but may/may not be eligible to be deleted.
 	}
 
-	if deploymentName != "" {
+	if managedK8Deployment {
 		result.Deployment = &v1.ObjectReference{
-			Namespace: "foo",
-			Name:      deploymentName,
+			Namespace: testNamespace,
+			Name:      deploymentName + k8sResourceNameSeparator + buildID,
 		}
-	} else {
-		panic("deploymentName required")
 	}
 
 	return &result
 }
 
-// TODO(carlydf): Make these tests align with VersionStatus instead of reachability
+func clearResourceVersion(obj metav1.Object) {
+	obj.SetResourceVersion("")
+}
+
 func TestGeneratePlan(t *testing.T) {
 	type testCase struct {
-		observedState *temporaliov1alpha1.TemporalWorkerDeploymentStatus
-		desiredState  *temporaliov1alpha1.TemporalWorkerDeploymentSpec
-		expectedPlan  plan
+		workerDeploymentName string
+		observedReplicas     int32
+		desiredReplicas      int32
+		observedState        *temporaliov1alpha1.TemporalWorkerDeploymentStatus
+		desiredState         *temporaliov1alpha1.TemporalWorkerDeploymentSpec
+		expectedPlan         plan
 	}
 
 	testCases := map[string]testCase{
 		"no action needed": {
+			workerDeploymentName: "foo",
+			observedReplicas:     3,
+			desiredReplicas:      3,
 			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
-				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo-a"), // prev reachable
+				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo", "a", true),
 			},
 			desiredState: newTestWorkerSpec(3),
-			expectedPlan: plan{},
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "foo",
+				DeleteDeployments:    nil,
+				CreateDeployment:     nil,
+				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
+				UpdateVersionConfig:  nil,
+			},
 		},
-		"create deployment version": {
+		"scale up inactive deployments if the number of replicas don't match": {
+			workerDeploymentName: "fia",
+			observedReplicas:     0,
+			desiredReplicas:      3,
 			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
-				DefaultVersion: &temporaliov1alpha1.WorkerDeploymentVersion{
-					Status:    temporaliov1alpha1.VersionStatusInactive, // prev reachable
-					VersionID: "foo-a.a",
+				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "fia", "a", true),
 				},
+			},
+			desiredState: newTestWorkerSpec(3),
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "fia",
+				DeleteDeployments:    nil,
+				CreateDeployment:     nil,
+				ScaleDeployments: map[*v1.ObjectReference]uint32{
+					&v1.ObjectReference{
+						Namespace: testNamespace,
+						Name:      "fia-a",
+					}: 3,
+				},
+				UpdateVersionConfig: nil,
+			},
+		},
+		"scale up ramping deployment if the number of replicas don't match": {
+			workerDeploymentName: "fii",
+			observedReplicas:     0,
+			desiredReplicas:      3,
+			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
+				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusRamping, "fii", "b", true),
+				},
+			},
+			desiredState: newTestWorkerSpec(3),
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "fii",
+				DeleteDeployments:    nil,
+				CreateDeployment:     nil,
+				ScaleDeployments: map[*v1.ObjectReference]uint32{
+					&v1.ObjectReference{
+						Namespace: testNamespace,
+						Name:      "fii-b",
+					}: 3,
+				},
+				UpdateVersionConfig: nil,
+			},
+		},
+		"scale up current deployment if the number of replicas don't match": {
+			workerDeploymentName: "aii",
+			observedReplicas:     0,
+			desiredReplicas:      3,
+			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
+				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusCurrent, "aii", "a", true),
+				},
+			},
+			desiredState: newTestWorkerSpec(3),
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "aii",
+				DeleteDeployments:    nil,
+				CreateDeployment:     nil,
+				ScaleDeployments: map[*v1.ObjectReference]uint32{
+					&v1.ObjectReference{
+						Namespace: testNamespace,
+						Name:      "aii-a",
+					}: 3,
+				},
+				UpdateVersionConfig: nil,
+			},
+		},
+		"create new k8s deployment from the pod template ": {
+			workerDeploymentName: "baz",
+			observedReplicas:     3,
+			desiredReplicas:      3,
+			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
+				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "baz", "a", true),
+				// k8 deployment does not exist and will be created from the pod template
+				TargetVersion:      newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "baz", "b", false),
 				DeprecatedVersions: nil,
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				DeleteDeployments:   nil,
-				CreateDeployment:    newTestDeployment(testPodTemplate, 3),
-				UpdateVersionConfig: nil,
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "baz",
+				DeleteDeployments:    nil,
+				CreateDeployment:     newTestDeploymentWithHashedBuildID(testPodTemplate, newTestWorkerSpec(3), "baz"),
+				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
+				UpdateVersionConfig:  nil,
 			},
 		},
 		"delete unreachable deployment versions": {
+			workerDeploymentName: "bar",
+			observedReplicas:     3,
+			desiredReplicas:      3,
 			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
-				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo-a"), // prev reachable
+				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "bar", "a", true),
 				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
-					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo-b"), // prev unreachable
-					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo-c"), // prev reachable
-					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusInactive, "foo-d"), // prev unreachable
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusNotRegistered, "bar", "b", true),
 				},
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "bar",
 				DeleteDeployments: []*appsv1.Deployment{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "foo",
-							Name:      "foo-b",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Namespace: "foo",
-							Name:      "foo-d",
-						},
-					},
+					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(3), "bar", "b"),
+				},
+				ScaleDeployments:    map[*v1.ObjectReference]uint32{},
+				CreateDeployment:    nil,
+				UpdateVersionConfig: nil,
+			},
+		},
+		"delete deployment when scaled down to 0 replicas": {
+			workerDeploymentName: "def",
+			observedReplicas:     0,
+			desiredReplicas:      0,
+			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
+				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusDrained, "def", "a", true),
+				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusDrained, "def", "b", true),
+				},
+			},
+			desiredState: newTestWorkerSpec(0),
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "def",
+				DeleteDeployments: []*appsv1.Deployment{
+					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(0), "def", "b"),
 				},
 				CreateDeployment:    nil,
+				ScaleDeployments:    make(map[*v1.ObjectReference]uint32),
+				UpdateVersionConfig: nil,
+			},
+		},
+		"don't delete deployment if not scaled down to 0 replicas even though it's past scaledown + delete delay": {
+			workerDeploymentName: "abc",
+			observedReplicas:     3,
+			desiredReplicas:      3,
+			observedState: &temporaliov1alpha1.TemporalWorkerDeploymentStatus{
+				DefaultVersion: newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusDrained, "abc", "a", true),
+				DeprecatedVersions: []*temporaliov1alpha1.WorkerDeploymentVersion{
+					newTestWorkerDeploymentVersion(temporaliov1alpha1.VersionStatusDrained, "abc", "b", true),
+				},
+			},
+			desiredState: newTestWorkerSpec(3),
+			expectedPlan: plan{
+				TemporalNamespace:    testNamespace,
+				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "abc",
+				DeleteDeployments:    nil,
+				CreateDeployment:     nil,
+				ScaleDeployments: map[*v1.ObjectReference]uint32{
+					&v1.ObjectReference{
+						Namespace: testNamespace,
+						Name:      "abc-b",
+					}: 0,
+				},
 				UpdateVersionConfig: nil,
 			},
 		},
 	}
 
-	//env := envtest.Environment{}
+	// Create a new scheme and client for each test case to avoid state bleeding
+	scheme := runtime.NewScheme()
+	_ = temporaliov1alpha1.AddToScheme(scheme)
+	_ = appsv1.AddToScheme(scheme) // Add this to register Deployment type
 
-	c := fake.NewFakeClient()
-
-	//c, err := client.New(nil, client.Options{
-	//	HTTPClient:     env.Config,
-	//	Scheme:         nil,
-	//	Mapper:         nil,
-	//	Cache:          nil,
-	//	WarningHandler: client.WarningHandlerOptions{},
-	//	DryRun:         nil,
-	//})
-	//if err != nil {
-	//	t.Fatal(err)
-	//}
+	// Create the fake client
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		Build()
 
 	r := &TemporalWorkerDeploymentReconciler{
 		Client: c,
+		Scheme: scheme,
 	}
 
 	for name, tc := range testCases {
 		t.Run(name, func(t *testing.T) {
-			actualPlan, err := r.generatePlan(context.Background(), log.FromContext(context.Background()), &temporaliov1alpha1.TemporalWorkerDeployment{
-				TypeMeta:   metav1.TypeMeta{},
-				ObjectMeta: metav1.ObjectMeta{},
-				Spec:       *tc.desiredState,
-				Status:     *tc.observedState,
-			}, temporaliov1alpha1.TemporalConnectionSpec{})
+
+			// Create the TemporalWorkerDeployment resource.
+			worker := &temporaliov1alpha1.TemporalWorkerDeployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "temporal.io/v1alpha1",
+					Kind:       "TemporalWorkerDeployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNamespace,
+					Name:      tc.workerDeploymentName,
+				},
+				Spec:   *tc.desiredState,
+				Status: *tc.observedState,
+			}
+			err := c.Create(context.Background(), worker)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create the Deployments referenced in the status
+			if tc.observedState.DefaultVersion != nil && tc.observedState.DefaultVersion.Deployment != nil {
+				deployment := newTestDeploymentWithHashedBuildID(testPodTemplate, newTestWorkerSpec(tc.observedReplicas), tc.workerDeploymentName)
+				deployment.Name = tc.observedState.DefaultVersion.Deployment.Name
+				deployment.Namespace = tc.observedState.DefaultVersion.Deployment.Namespace
+				err = c.Create(context.Background(), deployment)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Create the Deployments referenced in the deprecated versions
+			for _, version := range tc.observedState.DeprecatedVersions {
+				if version.Deployment != nil {
+					buildID := strings.Split(version.VersionID, versionIDSeparator)[1]
+					deployment := newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(tc.observedReplicas), tc.workerDeploymentName, buildID)
+
+					deployment.Name = version.Deployment.Name
+					deployment.Namespace = version.Deployment.Namespace
+					err = c.Create(context.Background(), deployment)
+					if err != nil {
+						t.Fatal(err)
+					}
+				}
+			}
+
+			actualPlan, err := r.generatePlan(
+				context.Background(),
+				log.FromContext(context.Background()),
+				worker,
+				temporaliov1alpha1.TemporalConnectionSpec{},
+			)
 			assert.NoError(t, err)
-			assert.Equal(t, &tc.expectedPlan, actualPlan)
+
+			// Clear ResourceVersion before comparison
+			if actualPlan.CreateDeployment != nil {
+				clearResourceVersion(actualPlan.CreateDeployment)
+			}
+			for _, d := range actualPlan.DeleteDeployments {
+				clearResourceVersion(d)
+			}
+
+			assertEqualPlans(t, &tc.expectedPlan, actualPlan)
 		})
+
 	}
 }
 
-func TestConvertFloatToUint(t *testing.T) {
-	assert.Equal(t, uint8(1), convertFloatToUint(1.1))
+// assertEqualPlans checks that the two plans are equal by conducting a deep comparsion of all the fields.
+// Unlike assert.Equal, however, this function does not deep-compare the keys in the scale deployments map since
+// the values are pointers to the deployment objects.
+func assertEqualPlans(t *testing.T, expectedPlan *plan, actualPlan *plan) {
+
+	assert.Equal(t, expectedPlan.TemporalNamespace, actualPlan.TemporalNamespace)
+	assert.Equal(t, expectedPlan.WorkerDeploymentName, actualPlan.WorkerDeploymentName)
+	assert.Equal(t, expectedPlan.DeleteDeployments, actualPlan.DeleteDeployments)
+	assert.Equal(t, expectedPlan.CreateDeployment, actualPlan.CreateDeployment)
+	assert.Equal(t, expectedPlan.UpdateVersionConfig, actualPlan.UpdateVersionConfig)
+
+	// ignore key values in the scale deployments map since they are pointers to the deployment objects.
+	assert.Equal(t, len(expectedPlan.ScaleDeployments), len(actualPlan.ScaleDeployments))
+
+	// Verify whether the right values are present in the scale deployments map
+	for k, v := range expectedPlan.ScaleDeployments {
+		found := false
+		for k2, v2 := range actualPlan.ScaleDeployments {
+			if k.Name == k2.Name {
+				found = true
+				assert.Equal(t, v, v2)
+			}
+		}
+		assert.True(t, found)
+	}
 }

--- a/internal/controller/worker_controller_test.go
+++ b/internal/controller/worker_controller_test.go
@@ -40,7 +40,7 @@ var (
 		},
 	}
 
-	testNamespace = "ns"
+	testTemporalNamespace = "ns"
 )
 
 // Hash is always taken of Spec.Template for generating the buildID.
@@ -49,7 +49,7 @@ func newTestWorkerSpec(replicas int32) *temporaliov1alpha1.TemporalWorkerDeploym
 		Replicas: &replicas,
 		Template: testPodTemplate,
 		WorkerOptions: temporaliov1alpha1.WorkerOptions{
-			TemporalNamespace: testNamespace,
+			TemporalNamespace: testTemporalNamespace,
 		},
 	}
 }
@@ -68,7 +68,7 @@ func newTestDeploymentWithHashedBuildID(podSpec v1.PodTemplateSpec, desiredState
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testTemporalNamespace,
 			Name:      deploymentName + k8sResourceNameSeparator + buildID,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{{
@@ -102,7 +102,7 @@ func newTestDeploymentWithBuildID(podSpec v1.PodTemplateSpec, desiredState *temp
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{},
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: testNamespace,
+			Namespace: testTemporalNamespace,
 			Name:      deploymentName + k8sResourceNameSeparator + buildID,
 			Labels:    labels,
 			OwnerReferences: []metav1.OwnerReference{{
@@ -127,7 +127,7 @@ func newTestDeploymentWithBuildID(podSpec v1.PodTemplateSpec, desiredState *temp
 func newTestWorkerDeploymentVersion(status temporaliov1alpha1.VersionStatus, deploymentName string, buildID string, managedK8Deployment bool) *temporaliov1alpha1.WorkerDeploymentVersion {
 	result := temporaliov1alpha1.WorkerDeploymentVersion{
 		HealthySince:   nil,
-		VersionID:      deploymentName + deploymentNameSeparator + testNamespace + versionIDSeparator + buildID,
+		VersionID:      deploymentName + deploymentNameSeparator + testTemporalNamespace + versionIDSeparator + buildID,
 		Status:         status,
 		RampPercentage: nil,
 		Deployment:     nil,
@@ -136,7 +136,7 @@ func newTestWorkerDeploymentVersion(status temporaliov1alpha1.VersionStatus, dep
 
 	if managedK8Deployment {
 		result.Deployment = &v1.ObjectReference{
-			Namespace: testNamespace,
+			Namespace: testTemporalNamespace,
 			Name:      deploymentName + k8sResourceNameSeparator + buildID,
 		}
 	}
@@ -168,8 +168,8 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "foo" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "foo" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
@@ -187,13 +187,13 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "fia" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "fia" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
 					&v1.ObjectReference{
-						Namespace: testNamespace,
+						Namespace: testTemporalNamespace,
 						Name:      "fia-a",
 					}: 3,
 				},
@@ -211,13 +211,13 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "fii" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "fii" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
 					&v1.ObjectReference{
-						Namespace: testNamespace,
+						Namespace: testTemporalNamespace,
 						Name:      "fii-b",
 					}: 3,
 				},
@@ -235,13 +235,13 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "aii" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "aii" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
 					&v1.ObjectReference{
-						Namespace: testNamespace,
+						Namespace: testTemporalNamespace,
 						Name:      "aii-a",
 					}: 3,
 				},
@@ -260,8 +260,8 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "baz" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "baz" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     newTestDeploymentWithHashedBuildID(testPodTemplate, newTestWorkerSpec(3), "baz"),
 				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
@@ -280,8 +280,8 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "bar" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "bar" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments: []*appsv1.Deployment{
 					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(3), "bar", "b"),
 				},
@@ -302,8 +302,8 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(0),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "def" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "def" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments: []*appsv1.Deployment{
 					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(0), "def", "b"),
 				},
@@ -324,13 +324,13 @@ func TestGeneratePlan(t *testing.T) {
 			},
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
-				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: "abc" + deploymentNameSeparator + testNamespace,
+				TemporalNamespace:    testTemporalNamespace,
+				WorkerDeploymentName: "abc" + deploymentNameSeparator + testTemporalNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
 					&v1.ObjectReference{
-						Namespace: testNamespace,
+						Namespace: testTemporalNamespace,
 						Name:      "abc-b",
 					}: 0,
 				},
@@ -364,7 +364,7 @@ func TestGeneratePlan(t *testing.T) {
 					Kind:       "TemporalWorkerDeployment",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: testNamespace,
+					Namespace: testTemporalNamespace,
 					Name:      tc.workerDeploymentName,
 				},
 				Spec:   *tc.desiredState,

--- a/internal/controller/worker_controller_test.go
+++ b/internal/controller/worker_controller_test.go
@@ -169,7 +169,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "foo",
+				WorkerDeploymentName: "foo" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
@@ -188,7 +188,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "fia",
+				WorkerDeploymentName: "fia" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
@@ -212,7 +212,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "fii",
+				WorkerDeploymentName: "fii" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
@@ -236,7 +236,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "aii",
+				WorkerDeploymentName: "aii" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{
@@ -261,7 +261,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "baz",
+				WorkerDeploymentName: "baz" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     newTestDeploymentWithHashedBuildID(testPodTemplate, newTestWorkerSpec(3), "baz"),
 				ScaleDeployments:     make(map[*v1.ObjectReference]uint32),
@@ -281,7 +281,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "bar",
+				WorkerDeploymentName: "bar" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments: []*appsv1.Deployment{
 					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(3), "bar", "b"),
 				},
@@ -303,7 +303,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(0),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "def",
+				WorkerDeploymentName: "def" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments: []*appsv1.Deployment{
 					newTestDeploymentWithBuildID(testPodTemplate, newTestWorkerSpec(0), "def", "b"),
 				},
@@ -325,7 +325,7 @@ func TestGeneratePlan(t *testing.T) {
 			desiredState: newTestWorkerSpec(3),
 			expectedPlan: plan{
 				TemporalNamespace:    testNamespace,
-				WorkerDeploymentName: testNamespace + deploymentNameSeparator + "abc",
+				WorkerDeploymentName: "abc" + deploymentNameSeparator + testNamespace,
 				DeleteDeployments:    nil,
 				CreateDeployment:     nil,
 				ScaleDeployments: map[*v1.ObjectReference]uint32{


### PR DESCRIPTION
With this PR:

1. Deleting a deployment is only possible when:
a) is has been scaled down to have 0 replicas
b) the deployment has been drained for deleteDelay + scaledownDelay.

2. Unit test refactor and additions for `genPlan`.
